### PR TITLE
Added support for nested array fieldConfig

### DIFF
--- a/src/components/ui/auto-form/fields/array.tsx
+++ b/src/components/ui/auto-form/fields/array.tsx
@@ -10,17 +10,20 @@ import AutoFormObject from "./object";
 import { Button } from "../../button";
 import { Plus, Trash } from "lucide-react";
 import { Separator } from "../../separator";
+import { FieldConfig } from '../types';
 
 export default function AutoFormArray({
   name,
   item,
   form,
   path = [],
+  fieldConfig,
 }: {
   name: string;
   item: z.ZodArray<any>;
   form: ReturnType<typeof useForm>;
   path?: string[];
+  fieldConfig?: any
 }) {
   const { fields, append, remove } = useFieldArray({
     control: form.control,
@@ -39,6 +42,7 @@ export default function AutoFormArray({
               <AutoFormObject
                 schema={item._def.type as z.ZodObject<any, any>}
                 form={form}
+                fieldConfig={fieldConfig}
                 path={[...path, index.toString()]}
               />
               <Button

--- a/src/components/ui/auto-form/fields/object.tsx
+++ b/src/components/ui/auto-form/fields/object.tsx
@@ -70,6 +70,7 @@ export default function AutoFormObject<
               name={name}
               item={item as unknown as z.ZodArray<any>}
               form={form}
+              fieldConfig={fieldConfig?.[name] ?? {}}
               path={[...path, name]}
             />
           );


### PR DESCRIPTION
This should work now by passing the filedConfig to the AutoFormArray 

```
const formSchema = z.object({
      title: z.string(),
      agendaItems: z
        .array(
          // Define the fields for each item
            z.object({
              name: z.string(),
              age: z.coerce.number(),
            }),
        )
        .describe('Agenda items'),
    })

<AutoForm
  formSchema={formSchema}
  fieldConfig={{
    agendaItems: { // <--------------------- HERE
      name: {
        fieldType: 'textarea',
        description: 'Name textarea', 
      },
    },
  }}
  onSubmit={(values) => {

  }}
>
  
      <AutoFormSubmit>Save</AutoFormSubmit>

</AutoForm>
              
```