### PR TITLE
fix: Select and shadcn FieldWrapper component

### DIFF
--- a/apps/web/cypress/component/autoform/ant-joi/basics.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-joi/basics.cy.tsx
@@ -3,6 +3,14 @@ import Joi from "joi";
 import { AutoForm } from "@autoform/ant";
 import { JoiProvider } from "@autoform/joi";
 
+enum Sports {
+  Football = "Football/Soccer",
+  Basketball = "Basketballs",
+  Baseball = "Baseballs",
+  Hockey = "Hockey (Ice)",
+  None = "I don't like sports",
+}
+
 describe("AutoForm Basic Tests (ANT-JOI)", () => {
   const basicSchema = Joi.object({
     name: Joi.string().min(2).required().messages({
@@ -20,6 +28,7 @@ describe("AutoForm Basic Tests (ANT-JOI)", () => {
     website: Joi.string().uri().optional().messages({
       "string.uri": "Invalid URL",
     }),
+    sports: Joi.valid(...Object.values(Sports)),
     birthdate: Joi.date().required(),
     isStudent: Joi.boolean().required(),
   });
@@ -39,11 +48,12 @@ describe("AutoForm Basic Tests (ANT-JOI)", () => {
     cy.get('input[name="age"]').should("have.class", "ant-input-number-input");
     cy.get('input[name="email"]').should("exist");
     cy.get('input[name="website"]').should("exist");
-    cy.get('input[name="birthdate"]');
     cy.get('input[name="isStudent"]').should(
       "have.class",
       "ant-checkbox-input"
     );
+    cy.get('input[id="sports"]').should("exist");
+    cy.get('input[name="birthdate"]');
   });
 
   it("submits form with correct data types", () => {
@@ -56,6 +66,8 @@ describe("AutoForm Basic Tests (ANT-JOI)", () => {
     cy.get('input[name="age"]').type("25");
     cy.get('input[name="email"]').type("john@example.com");
     cy.get('input[name="website"]').type("https://example.com");
+    cy.get('input[id="sports"]').click();
+    cy.get('.ant-select-item-option[title="Hockey (Ice)"]').click();
     cy.get('input[name="birthdate"]').clear().type("1990-01-01");
     cy.get('input[name="isStudent"]').check();
 
@@ -67,6 +79,7 @@ describe("AutoForm Basic Tests (ANT-JOI)", () => {
       age: 25,
       email: "john@example.com",
       website: "https://example.com",
+      sports: "Hockey (Ice)",
       birthdate: new Date("1990-01-01"),
       isStudent: true,
     });

--- a/apps/web/cypress/component/autoform/ant-zod/basic.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod/basic.cy.tsx
@@ -3,12 +3,21 @@ import { AutoForm } from "@autoform/ant";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
 import { z } from "zod/v3";
 
+enum Sports {
+  Football = "Football/Soccer",
+  Basketball = "Basketballs",
+  Baseball = "Baseballs",
+  Hockey = "Hockey (Ice)",
+  None = "I don't like sports",
+}
+
 describe("AutoForm Basic Tests (ANT-ZOD)", () => {
   const basicSchema = z.object({
     name: z.string().min(2, "Name must be at least 2 characters"),
     age: z.coerce.number().min(18, "Must be at least 18 years old"),
     email: z.string().email("Invalid email address"),
     website: z.string().url("Invalid URL").optional(),
+    sports: z.nativeEnum(Sports),
     birthdate: z.coerce.date(),
     isStudent: z.boolean(),
   });
@@ -28,7 +37,8 @@ describe("AutoForm Basic Tests (ANT-ZOD)", () => {
     cy.get('input[name="age"]').should("have.class", "ant-input-number-input");
     cy.get('input[name="email"]').should("exist");
     cy.get('input[name="website"]').should("exist");
-    cy.get('input[name="birthdate"]');
+    cy.get('input[id="sports"]').should("exist");
+    cy.get('input[name="birthdate"]').should("exist");
     cy.get('input[name="isStudent"]').should(
       "have.class",
       "ant-checkbox-input"
@@ -45,6 +55,8 @@ describe("AutoForm Basic Tests (ANT-ZOD)", () => {
     cy.get('input[name="age"]').type("25");
     cy.get('input[name="email"]').type("john@example.com");
     cy.get('input[name="website"]').type("https://example.com");
+    cy.get('input[id="sports"]').click();
+    cy.get('.ant-select-item-option[title="Hockey (Ice)"]').click();
     cy.get('input[name="birthdate"]').clear().type("1990-01-01");
     cy.get('input[name="isStudent"]').check();
 
@@ -56,6 +68,7 @@ describe("AutoForm Basic Tests (ANT-ZOD)", () => {
       age: 25,
       email: "john@example.com",
       website: "https://example.com",
+      sports: "Hockey (Ice)",
       birthdate: new Date("1990-01-01"),
       isStudent: true,
     });

--- a/apps/web/cypress/component/autoform/ant-zod4-mini/basics.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod4-mini/basics.cy.tsx
@@ -3,6 +3,14 @@ import { AutoForm } from "@autoform/ant";
 import { ZodProvider } from "@autoform/zod";
 import { z } from "zod/mini";
 
+enum Sports {
+  Football = "Football/Soccer",
+  Basketball = "Basketballs",
+  Baseball = "Baseballs",
+  Hockey = "Hockey (Ice)",
+  None = "I don't like sports",
+}
+
 describe("AutoForm Basic Tests (ANT-ZOD-V4-MINI)", () => {
   const basicSchema = z.object({
     name: z.string().check(
@@ -13,6 +21,7 @@ describe("AutoForm Basic Tests (ANT-ZOD-V4-MINI)", () => {
       z.gte(18)
       // Custom error messages are not supported in .check()
     ),
+    sports: z.enum(Sports),
     email: z.string(), // Zod Mini does not provide a built-in .email() check
     website: z.optional(z.string()), // .url() is not available in Zod Mini
     birthdate: z.coerce.date(),
@@ -34,7 +43,8 @@ describe("AutoForm Basic Tests (ANT-ZOD-V4-MINI)", () => {
     cy.get('input[name="age"]').should("have.class", "ant-input-number-input");
     cy.get('input[name="email"]').should("exist");
     cy.get('input[name="website"]').should("exist");
-    cy.get('input[name="birthdate"]');
+    cy.get('input[id="sports"]').should("exist");
+    cy.get('input[name="birthdate"]').should("exist");
     cy.get('input[name="isStudent"]').should(
       "have.class",
       "ant-checkbox-input"
@@ -51,6 +61,8 @@ describe("AutoForm Basic Tests (ANT-ZOD-V4-MINI)", () => {
     cy.get('input[name="age"]').type("25");
     cy.get('input[name="email"]').type("john@example.com");
     cy.get('input[name="website"]').type("https://example.com");
+    cy.get('input[id="sports"]').click();
+    cy.get('.ant-select-item-option[title="Hockey (Ice)"]').click();
     cy.get('input[name="birthdate"]').clear().type("1990-01-01");
     cy.get('input[name="isStudent"]').check();
 
@@ -62,6 +74,7 @@ describe("AutoForm Basic Tests (ANT-ZOD-V4-MINI)", () => {
       age: 25,
       email: "john@example.com",
       website: "https://example.com",
+      sports: "Hockey (Ice)",
       birthdate: new Date("1990-01-01"),
       isStudent: true,
     });

--- a/apps/web/cypress/component/autoform/chakra-zod/basic.cy.tsx
+++ b/apps/web/cypress/component/autoform/chakra-zod/basic.cy.tsx
@@ -3,12 +3,21 @@ import { AutoForm } from "@autoform/chakra";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
 import { z } from "zod/v3";
 
+enum Sports {
+  Football = "Football/Soccer",
+  Basketball = "Basketballs",
+  Baseball = "Baseballs",
+  Hockey = "Hockey (Ice)",
+  None = "I don't like sports",
+}
+
 describe("AutoForm Basic Tests (CHAKRA-ZOD)", () => {
   const basicSchema = z.object({
     name: z.string().min(2, "Name must be at least 2 characters"),
     age: z.coerce.number().min(18, "Must be at least 18 years old"),
     email: z.string().email("Invalid email address"),
     website: z.string().url("Invalid URL").optional(),
+    sports: z.nativeEnum(Sports),
     birthdate: z.coerce.date(),
     isStudent: z.boolean(),
   });
@@ -32,6 +41,7 @@ describe("AutoForm Basic Tests (CHAKRA-ZOD)", () => {
     );
     cy.get('input[name="email"]').should("exist");
     cy.get('input[name="website"]').should("exist");
+    cy.get('select[name="sports"]').should("exist");
     cy.get('input[name="birthdate"]');
     cy.get('input[name="isStudent"]').should("have.attr", "type", "checkbox");
   });
@@ -46,6 +56,12 @@ describe("AutoForm Basic Tests (CHAKRA-ZOD)", () => {
     cy.get('input[name="age"]').type("25");
     cy.get('input[name="email"]').type("john@example.com");
     cy.get('input[name="website"]').type("https://example.com");
+    cy.get(".chakra-select__root")
+      .within(() => {
+        cy.get('select[name="sports"]').should("exist");
+      })
+      .click();
+    cy.get('.chakra-select__item[data-value="Hockey (Ice)"]').click();
     cy.get('input[name="birthdate"]').clear().type("1990-01-01");
     cy.get('input[name="isStudent"]')
       .parent()
@@ -60,6 +76,7 @@ describe("AutoForm Basic Tests (CHAKRA-ZOD)", () => {
       age: 25,
       email: "john@example.com",
       website: "https://example.com",
+      sports: "Hockey (Ice)",
       birthdate: new Date("1990-01-01"),
       isStudent: true,
     });

--- a/apps/web/cypress/component/autoform/mantine-zod/basic.cy.tsx
+++ b/apps/web/cypress/component/autoform/mantine-zod/basic.cy.tsx
@@ -4,12 +4,21 @@ import { ZodProvider, fieldConfig } from "@autoform/zod";
 import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
+enum Sports {
+  Football = "Football/Soccer",
+  Basketball = "Basketballs",
+  Baseball = "Baseballs",
+  Hockey = "Hockey (Ice)",
+  None = "I don't like sports",
+}
+
 describe("AutoForm Basic Tests (MANTINE-ZOD)", () => {
   const basicSchema = z.object({
     name: z.string().min(2, "Name must be at least 2 characters"),
     age: z.coerce.number().min(18, "Must be at least 18 years old"),
     email: z.string().email("Invalid email address"),
     website: z.string().url("Invalid URL").optional(),
+    sports: z.nativeEnum(Sports),
     birthdate: z.coerce.date(),
     isStudent: z.boolean(),
   });
@@ -31,6 +40,7 @@ describe("AutoForm Basic Tests (MANTINE-ZOD)", () => {
     cy.get('input[name="age"]').should("have.attr", "type", "number");
     cy.get('input[name="email"]').should("exist");
     cy.get('input[name="website"]').should("exist");
+    cy.get('input[name="sports"]').should("exist");
     cy.get('[data-dates-input="true"]').should("exist");
     cy.get('input[name="isStudent"]').should("have.attr", "type", "checkbox");
   });
@@ -47,9 +57,13 @@ describe("AutoForm Basic Tests (MANTINE-ZOD)", () => {
     cy.get('input[name="age"]').type("25");
     cy.get('input[name="email"]').type("john@example.com");
     cy.get('input[name="website"]').type("https://example.com");
-    cy.get('[data-dates-input="true"]').type("1990-01-01");
     cy.get('input[name="isStudent"]').check();
-
+    cy.get(".mantine-Select-input").eq(0).click();
+    cy.get('.mantine-Select-option[value="Hockey (Ice)"]')
+      .should("exist")
+      .and("be.visible")
+      .click();
+    cy.get('[data-dates-input="true"]').type("1990-01-01");
     cy.get('button[type="submit"]').click();
 
     cy.get("@onSubmit").should("have.been.calledOnce");
@@ -58,6 +72,7 @@ describe("AutoForm Basic Tests (MANTINE-ZOD)", () => {
       age: 25,
       email: "john@example.com",
       website: "https://example.com",
+      sports: "Hockey (Ice)",
       birthdate: new Date("1990-01-01"),
       isStudent: true,
     });

--- a/apps/web/cypress/component/autoform/mui-yup/basics.cy.tsx
+++ b/apps/web/cypress/component/autoform/mui-yup/basics.cy.tsx
@@ -3,12 +3,21 @@ import { AutoForm } from "@autoform/mui";
 import { YupProvider, fieldConfig } from "@autoform/yup";
 import * as Yup from "yup";
 
+enum Sports {
+  Football = "Football/Soccer",
+  Basketball = "Basketballs",
+  Baseball = "Baseballs",
+  Hockey = "Hockey (Ice)",
+  None = "I don't like sports",
+}
+
 describe("AutoForm Basic Tests (MUI-YUP)", () => {
   const basicSchema = Yup.object({
     name: Yup.string().min(2, "Name must be at least 2 characters"),
     age: Yup.number().min(18, "Must be at least 18 years old"),
     email: Yup.string().email("Invalid email address"),
     website: Yup.string().url("Invalid URL").optional(),
+    sports: Yup.mixed().oneOf(Object.values(Sports)),
     birthdate: Yup.date(),
     isStudent: Yup.boolean(),
   });
@@ -28,6 +37,7 @@ describe("AutoForm Basic Tests (MUI-YUP)", () => {
     cy.get('input[name="age"]').should("have.attr", "type", "number");
     cy.get('input[name="email"]').should("exist");
     cy.get('input[name="website"]').should("exist");
+    cy.get('input[name="sports"]').should("exist");
     cy.get('input[name="birthdate"]').should("have.attr", "type", "date");
     cy.get('input[name="isStudent"]').should("have.attr", "type", "checkbox");
   });
@@ -42,6 +52,8 @@ describe("AutoForm Basic Tests (MUI-YUP)", () => {
     cy.get('input[name="age"]').type("25");
     cy.get('input[name="email"]').type("john@example.com");
     cy.get('input[name="website"]').type("https://example.com");
+    cy.get("#mui-component-select-sports").click();
+    cy.get('.MuiMenuItem-root[data-value="Hockey (Ice)"]').click();
     cy.get('input[name="birthdate"]').type("1990-01-01");
     cy.get('input[name="isStudent"]').check();
 
@@ -53,6 +65,7 @@ describe("AutoForm Basic Tests (MUI-YUP)", () => {
       age: 25,
       email: "john@example.com",
       website: "https://example.com",
+      sports: "Hockey (Ice)",
       birthdate: new Date("1990-01-01"),
       isStudent: true,
     });

--- a/apps/web/cypress/component/autoform/mui-zod/basic.cy.tsx
+++ b/apps/web/cypress/component/autoform/mui-zod/basic.cy.tsx
@@ -3,12 +3,21 @@ import { AutoForm } from "@autoform/mui";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
 import { z } from "zod/v3";
 
+enum Sports {
+  Football = "Football/Soccer",
+  Basketball = "Basketballs",
+  Baseball = "Baseballs",
+  Hockey = "Hockey (Ice)",
+  None = "I don't like sports",
+}
+
 describe("AutoForm Basic Tests (MUI-ZOD)", () => {
   const basicSchema = z.object({
     name: z.string().min(2, "Name must be at least 2 characters"),
     age: z.coerce.number().min(18, "Must be at least 18 years old"),
     email: z.string().email("Invalid email address"),
     website: z.string().url("Invalid URL").optional(),
+    sports: z.nativeEnum(Sports),
     birthdate: z.coerce.date(),
     isStudent: z.boolean(),
   });
@@ -28,6 +37,7 @@ describe("AutoForm Basic Tests (MUI-ZOD)", () => {
     cy.get('input[name="age"]').should("have.attr", "type", "number");
     cy.get('input[name="email"]').should("exist");
     cy.get('input[name="website"]').should("exist");
+    cy.get('input[name="sports"]').should("exist");
     cy.get('input[name="birthdate"]').should("have.attr", "type", "date");
     cy.get('input[name="isStudent"]').should("have.attr", "type", "checkbox");
   });
@@ -42,6 +52,8 @@ describe("AutoForm Basic Tests (MUI-ZOD)", () => {
     cy.get('input[name="age"]').type("25");
     cy.get('input[name="email"]').type("john@example.com");
     cy.get('input[name="website"]').type("https://example.com");
+    cy.get("#mui-component-select-sports").click();
+    cy.get('.MuiMenuItem-root[data-value="Hockey (Ice)"]').click();
     cy.get('input[name="birthdate"]').type("1990-01-01");
     cy.get('input[name="isStudent"]').check();
 
@@ -53,6 +65,7 @@ describe("AutoForm Basic Tests (MUI-ZOD)", () => {
       age: 25,
       email: "john@example.com",
       website: "https://example.com",
+      sports: "Hockey (Ice)",
       birthdate: new Date("1990-01-01"),
       isStudent: true,
     });

--- a/apps/web/cypress/component/autoform/shadcn-zod/basic.cy.tsx
+++ b/apps/web/cypress/component/autoform/shadcn-zod/basic.cy.tsx
@@ -4,12 +4,21 @@ import { ZodProvider, fieldConfig } from "@autoform/zod";
 import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
+enum Sports {
+  Football = "Football/Soccer",
+  Basketball = "Basketballs",
+  Baseball = "Baseballs",
+  Hockey = "Hockey (Ice)",
+  None = "I don't like sports",
+}
+
 describe("AutoForm Basic Tests (SHADCN-ZOD)", () => {
   const basicSchema = z.object({
     name: z.string().min(2, "Name must be at least 2 characters"),
     age: z.coerce.number().min(18, "Must be at least 18 years old"),
     email: z.string().email("Invalid email address"),
     website: z.string().url("Invalid URL").optional(),
+    sports: z.nativeEnum(Sports),
     birthdate: z.coerce.date(),
     isStudent: z.boolean(),
   });
@@ -31,6 +40,7 @@ describe("AutoForm Basic Tests (SHADCN-ZOD)", () => {
     cy.get('input[name="age"]').should("have.attr", "type", "number");
     cy.get('input[name="email"]').should("exist");
     cy.get('input[name="website"]').should("exist");
+    cy.get('button[name="sports"]').should("exist");
     cy.get('input[name="birthdate"]').should("exist");
     cy.get("button#isStudent").should("exist");
   });
@@ -47,6 +57,11 @@ describe("AutoForm Basic Tests (SHADCN-ZOD)", () => {
     cy.get('input[name="age"]').type("25");
     cy.get('input[name="email"]').type("john@example.com");
     cy.get('input[name="website"]').type("https://example.com");
+    cy.get('button[name="sports"]').should("exist").click();
+    cy.get('div[data-radix-collection-item][role="option"]')
+      .should("be.visible")
+      .contains("Hockey (Ice)")
+      .click();
     cy.get('input[name="birthdate"]').type("1990-01-01");
     cy.get("button#isStudent").click();
 
@@ -58,6 +73,7 @@ describe("AutoForm Basic Tests (SHADCN-ZOD)", () => {
       age: 25,
       email: "john@example.com",
       website: "https://example.com",
+      sports: "Hockey (Ice)",
       birthdate: new Date("1990-01-01"),
       isStudent: true,
     });

--- a/apps/web/cypress/component/autoform/shadcn-zod4/basic.cy.tsx
+++ b/apps/web/cypress/component/autoform/shadcn-zod4/basic.cy.tsx
@@ -4,12 +4,21 @@ import { ZodProvider, fieldConfig } from "@autoform/zod";
 import { z } from "zod/v4";
 import { TestWrapper } from "./utils";
 
+enum Sports {
+  Football = "Football/Soccer",
+  Basketball = "Basketballs",
+  Baseball = "Baseballs",
+  Hockey = "Hockey (Ice)",
+  None = "I don't like sports",
+}
+
 describe("AutoForm Basic Tests (SHADCN-ZOD-V4)", () => {
   const basicSchema = z.object({
     name: z.string().min(2, "Name must be at least 2 characters"),
     age: z.coerce.number().min(18, "Must be at least 18 years old"),
     email: z.string().email("Invalid email address"),
     website: z.string().url("Invalid URL").optional(),
+    sports: z.enum(Sports),
     birthdate: z.coerce.date(),
     isStudent: z.boolean(),
   });
@@ -31,6 +40,7 @@ describe("AutoForm Basic Tests (SHADCN-ZOD-V4)", () => {
     cy.get('input[name="age"]').should("have.attr", "type", "number");
     cy.get('input[name="email"]').should("exist");
     cy.get('input[name="website"]').should("exist");
+    cy.get('button[name="sports"]').should("exist");
     cy.get('input[name="birthdate"]').should("exist");
     cy.get("button#isStudent").should("exist");
   });
@@ -47,6 +57,11 @@ describe("AutoForm Basic Tests (SHADCN-ZOD-V4)", () => {
     cy.get('input[name="age"]').type("25");
     cy.get('input[name="email"]').type("john@example.com");
     cy.get('input[name="website"]').type("https://example.com");
+    cy.get('button[name="sports"]').should("exist").click();
+    cy.get('div[data-radix-collection-item][role="option"]')
+      .should("be.visible")
+      .contains("Hockey (Ice)")
+      .click();
     cy.get('input[name="birthdate"]').type("1990-01-01");
     cy.get("button#isStudent").click();
 
@@ -58,6 +73,7 @@ describe("AutoForm Basic Tests (SHADCN-ZOD-V4)", () => {
       age: 25,
       email: "john@example.com",
       website: "https://example.com",
+      sports: "Hockey (Ice)",
       birthdate: new Date("1990-01-01"),
       isStudent: true,
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -22046,7 +22046,7 @@
     },
     "packages/zod": {
       "name": "@autoform/zod",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "devDependencies": {
         "@autoform/core": "*",
         "@autoform/eslint-config": "*",

--- a/packages/mantine/src/components/SelectField.tsx
+++ b/packages/mantine/src/components/SelectField.tsx
@@ -30,7 +30,7 @@ export const SelectField: React.FC<AutoFormFieldProps> = ({
       defaultValue={value}
       description={field.fieldConfig?.description}
       data={(field.options || []).map(([key, label]) => ({
-        value: key,
+        value: label,
         label,
       }))}
     />

--- a/packages/shadcn/src/components/ui/autoform/components/FieldWrapper.tsx
+++ b/packages/shadcn/src/components/ui/autoform/components/FieldWrapper.tsx
@@ -12,6 +12,7 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = ({
   error,
 }) => {
   const isDisabled = DISABLED_LABELS.includes(field.type);
+  const hideError = ["array", "object"].includes(field.type);
 
   return (
     <div className="space-y-2">
@@ -27,7 +28,9 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = ({
           {field.fieldConfig.description}
         </p>
       )}
-      {error && <p className="text-sm text-destructive">{error}</p>}
+      {!hideError && error && (
+        <p className="text-sm text-destructive">{error}</p>
+      )}
     </div>
   );
 };

--- a/packages/shadcn/src/components/ui/autoform/components/SelectField.tsx
+++ b/packages/shadcn/src/components/ui/autoform/components/SelectField.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/select";
 import { AutoFormFieldProps } from "@autoform/react";
 import React from "react";
+import { useController } from "react-hook-form";
 
 export const SelectField: React.FC<AutoFormFieldProps> = ({
   field,
@@ -14,28 +15,25 @@ export const SelectField: React.FC<AutoFormFieldProps> = ({
   error,
   id,
 }) => {
-  const { key, ...props } = inputProps;
+  const { key, onChange, onBlur, ref, ...props } = inputProps;
+  const { field: formField } = useController({ name: id });
 
   return (
     <Select
+      onValueChange={formField.onChange}
+      value={formField.value}
       {...props}
-      onValueChange={(value) => {
-        const syntheticEvent = {
-          target: {
-            value,
-            name: field.key,
-          },
-        } as React.ChangeEvent<HTMLInputElement>;
-        props.onChange(syntheticEvent);
-      }}
-      defaultValue={field.default}
     >
-      <SelectTrigger id={id} className={error ? "border-destructive" : ""}>
-        <SelectValue placeholder="Select an option" />
+      <SelectTrigger
+        id={id}
+        {...formField}
+        className={error ? "border-destructive" : ""}
+      >
+        <SelectValue placeholder={props.placeholder ?? "Select an option"} />
       </SelectTrigger>
       <SelectContent>
         {(field.options || []).map(([key, label]) => (
-          <SelectItem key={key} value={key}>
+          <SelectItem key={key} value={label}>
             {label}
           </SelectItem>
         ))}


### PR DESCRIPTION
Fixes: #190 (dual error in array field), #180, #182, and other select-related issues.


One thing I’d like to confirm — should the `<SelectItem>`  `value` remain as `key` (as before), or should we use the `label` ?
Ant and MUI use the label as the value, whereas Chakra, Mantine, and shadcn use the key.

```tsx
<SelectItem key={key} value={key}>
  {label}
</SelectItem>
```