### PR TITLE
feat: add Vue 3 integration (@autoform/vue)

### DIFF
--- a/.changeset/add-vue-integration.md
+++ b/.changeset/add-vue-integration.md
@@ -1,0 +1,5 @@
+---
+"@autoform/core": minor
+---
+
+Add Vue 3 integration package (@autoform/vue) with AutoForm component, useAutoForm composable, and complete documentation.

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -56,6 +56,7 @@ However, AutoForm does not aim to be a full-featured form builder. It does not a
 ## Installation
 
 - [React](/docs/react/getting-started)
+- [Vue](/docs/vue/getting-started)
 
 ## shadcn/ui component
 

--- a/apps/docs/content/docs/vue/api.mdx
+++ b/apps/docs/content/docs/vue/api.mdx
@@ -1,0 +1,125 @@
+---
+title: API Reference
+---
+
+## AutoForm component
+
+The main component that renders a form from a schema.
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `schema` | `SchemaProvider` | **required** | Schema provider instance (e.g. `ZodProvider`) |
+| `uiComponents` | `AutoFormUIComponents` | **required** | UI wrapper components |
+| `formComponents` | `AutoFormFieldComponents` | **required** | Field type components |
+| `withSubmit` | `boolean` | `false` | Show a submit button |
+| `defaultValues` | `Record<string, any>` | — | Initial form values |
+| `values` | `Record<string, any>` | — | Controlled form values (watched for changes) |
+| `formProps` | `Record<string, any>` | — | Extra attributes for the `<form>` element |
+
+### Events
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `submit` | `data: any` | Emitted with validated data on successful submit |
+| `formInit` | `{ values, errors, isSubmitting, reset, clearErrors }` | Emitted once on mount with form controls |
+
+### Exposed (via template ref)
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `values` | `Record<string, any>` | Reactive form values |
+| `errors` | `Ref<Record<string, string>>` | Validation errors |
+| `isSubmitting` | `Ref<boolean>` | Submission state |
+| `reset()` | `() => void` | Reset form to default values |
+
+```vue
+<script setup>
+const formRef = ref();
+// formRef.value.values, formRef.value.reset(), etc.
+</script>
+
+<template>
+  <AutoForm ref="formRef" ... />
+</template>
+```
+
+---
+
+## useAutoForm composable
+
+Injected context available in any component rendered inside `<AutoForm>`.
+
+```ts
+import { useAutoForm } from "@autoform/vue";
+
+const ctx = useAutoForm();
+```
+
+### Returns
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `schema` | `ParsedSchema` | Parsed schema with all fields |
+| `uiComponents` | `AutoFormUIComponents` | UI components passed to AutoForm |
+| `formComponents` | `AutoFormFieldComponents` | Field components passed to AutoForm |
+| `values` | `Record<string, any>` | Reactive form values |
+| `errors` | `Record<string, string>` | Current validation errors |
+| `setFieldValue(path, value)` | `Function` | Set a field value by dot-separated path |
+| `getFieldValue(path)` | `Function` | Get a field value by dot-separated path |
+| `getFieldError(path)` | `Function` | Get a field's error message |
+
+---
+
+## Utility functions
+
+### buildZodFieldConfig
+
+Type-safe helper for creating Zod field configs with Vue component types:
+
+```ts
+import { buildZodFieldConfig } from "@autoform/vue";
+
+const fieldConfig = buildZodFieldConfig();
+// Use with: z.string().superRefine(fieldConfig({ fieldType: "textarea" }))
+```
+
+### buildYupFieldConfig
+
+Same as above but for Yup schemas:
+
+```ts
+import { buildYupFieldConfig } from "@autoform/vue";
+```
+
+### getPathInObject / setPathInObject
+
+Utility functions for reading/writing nested values:
+
+```ts
+import { getPathInObject, setPathInObject } from "@autoform/vue";
+
+const obj = { user: { name: "John" } };
+getPathInObject(obj, ["user", "name"]); // "John"
+setPathInObject(obj, ["user", "age"], 30);
+```
+
+---
+
+## TypeScript types
+
+```ts
+import type {
+  AutoFormProps,
+  AutoFormUIComponents,
+  AutoFormFieldComponents,
+  AutoFormFieldProps,
+  AutoFormContextType,
+  FieldWrapperProps,
+  ObjectWrapperProps,
+  ArrayWrapperProps,
+  ArrayElementWrapperProps,
+  FieldConfig,
+} from "@autoform/vue";
+```

--- a/apps/docs/content/docs/vue/customization.md
+++ b/apps/docs/content/docs/vue/customization.md
@@ -1,0 +1,104 @@
+---
+title: Customization
+---
+
+## Custom field components
+
+You can override the default field component for any field type by passing custom components via the `formComponents` prop:
+
+```vue
+<template>
+  <AutoForm
+    :schema="schema"
+    :ui-components="uiComponents"
+    :form-components="{
+      string: MyCustomInput,
+      number: MyCustomNumberInput,
+      select: MyCustomSelect,
+      // 'fallback' is used for unknown field types
+      fallback: MyFallbackInput,
+    }"
+    @submit="onSubmit"
+  />
+</template>
+```
+
+### Field component props
+
+Every field component receives the following props:
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `label` | `string` | The field's label |
+| `field` | `ParsedField` | Full field metadata from the schema |
+| `value` | `any` | Current field value |
+| `error` | `string \| undefined` | Validation error message |
+| `id` | `string` | Unique field ID (dot-separated path) |
+| `path` | `string[]` | Field path as array |
+| `inputProps` | `object` | Contains `modelValue` and `onUpdate:modelValue` |
+
+### Using inputProps for v-model
+
+The `inputProps` object contains `modelValue` and `onUpdate:modelValue` to work with Vue's reactivity:
+
+```ts
+const MyInput = defineComponent({
+  props: ["field", "value", "error", "id", "inputProps"],
+  setup(props) {
+    return () =>
+      h("input", {
+        value: props.inputProps?.modelValue ?? "",
+        onInput: (e: Event) =>
+          props.inputProps?.["onUpdate:modelValue"]?.(
+            (e.target as HTMLInputElement).value
+          ),
+      });
+  },
+});
+```
+
+## Custom UI components
+
+UI components control the form's structure and layout. Override any of them via the `uiComponents` prop:
+
+| Component | Purpose | Required Props |
+|-----------|---------|---------------|
+| `Form` | Form wrapper | `onSubmit` (via attrs) |
+| `FieldWrapper` | Wraps each field with label and error | `label`, `error`, `id`, `field` |
+| `ErrorMessage` | Displays error messages | `error` |
+| `SubmitButton` | Submit button | — (uses default slot) |
+| `ObjectWrapper` | Wraps nested object fields | `label`, `field` |
+| `ArrayWrapper` | Wraps array fields | `label`, `field`, emits `addItem` |
+| `ArrayElementWrapper` | Wraps each array item | `index`, emits `remove` |
+
+## Custom field wrapper per field
+
+You can override the field wrapper for a specific field using `fieldConfig`:
+
+```ts
+import { fieldConfig } from "@autoform/zod";
+
+const schema = z.object({
+  name: z.string().superRefine(
+    fieldConfig({
+      fieldWrapper: MyCustomWrapper,
+    })
+  ),
+});
+```
+
+## Overriding field types
+
+Force a specific field type using `fieldConfig`:
+
+```ts
+const schema = z.object({
+  bio: z.string().superRefine(
+    fieldConfig({
+      fieldType: "textarea",
+    })
+  ),
+});
+```
+
+Then provide a `textarea` component in your `formComponents`.

--- a/apps/docs/content/docs/vue/getting-started.mdx
+++ b/apps/docs/content/docs/vue/getting-started.mdx
@@ -1,0 +1,292 @@
+---
+title: Getting Started
+---
+
+> New to AutoForm? Check out the [introduction](/docs) first.
+
+<div className='fd-steps [&_h2]:fd-step'>
+
+## Install the Vue integration
+
+```bash
+# Install the core package and Vue integration
+pnpm add @autoform/vue @autoform/core
+
+# Or with npm
+npm install @autoform/vue @autoform/core
+```
+
+## Install a schema provider
+
+#### Zod
+
+<ModeTab command="@autoform/zod" />
+
+#### Yup
+
+<ModeTab command="@autoform/yup" />
+
+In the docs, we will use Zod as an example but simply replace the imports with the ones from your schema library.
+
+## Create a form
+
+AutoForm for Vue requires two sets of components: **UI components** (form wrapper, field wrapper, submit button, etc.) and **field components** (text input, number input, select, etc.). You provide these as props, giving you full control over the rendering.
+
+```vue
+<script setup lang="ts">
+import { AutoForm } from "@autoform/vue";
+import { ZodProvider } from "@autoform/zod";
+import { z } from "zod";
+
+// Import your custom UI and field components
+import { uiComponents, fieldComponents } from "./my-autoform-components";
+
+const schema = new ZodProvider(
+  z.object({
+    name: z.string().min(2).describe("Full Name"),
+    email: z.string().email(),
+    age: z.number().min(18),
+    role: z.enum(["developer", "designer", "manager"]),
+  })
+);
+
+function onSubmit(data: any) {
+  console.log("Validated data:", data);
+}
+</script>
+
+<template>
+  <AutoForm
+    :schema="schema"
+    :ui-components="uiComponents"
+    :form-components="fieldComponents"
+    with-submit
+    @submit="onSubmit"
+  />
+</template>
+```
+
+## Defining UI components
+
+UI components are the structural wrappers for your form. You need to provide all of these:
+
+```ts
+import { defineComponent, h } from "vue";
+import type { AutoFormUIComponents } from "@autoform/vue";
+
+const Form = defineComponent({
+  setup(_, { slots, attrs }) {
+    return () => h("form", { ...attrs }, slots.default?.());
+  },
+});
+
+const FieldWrapper = defineComponent({
+  props: ["label", "error", "id", "field"],
+  setup(props, { slots }) {
+    return () =>
+      h("div", { class: "field" }, [
+        h("label", { for: props.id }, props.label),
+        slots.default?.(),
+        props.error ? h("p", { class: "error" }, props.error) : null,
+      ]);
+  },
+});
+
+const ErrorMessage = defineComponent({
+  props: ["error"],
+  setup(props) {
+    return () => h("p", { class: "error" }, props.error);
+  },
+});
+
+const SubmitButton = defineComponent({
+  setup(_, { slots }) {
+    return () => h("button", { type: "submit" }, slots.default?.());
+  },
+});
+
+const ObjectWrapper = defineComponent({
+  props: ["label", "field"],
+  setup(props, { slots }) {
+    return () =>
+      h("fieldset", [
+        h("legend", props.label),
+        slots.default?.(),
+      ]);
+  },
+});
+
+const ArrayWrapper = defineComponent({
+  props: ["label", "field"],
+  emits: ["addItem"],
+  setup(props, { slots, emit }) {
+    return () =>
+      h("div", [
+        h("h4", props.label),
+        slots.default?.(),
+        h("button", { type: "button", onClick: () => emit("addItem") }, "+ Add"),
+      ]);
+  },
+});
+
+const ArrayElementWrapper = defineComponent({
+  props: ["index"],
+  emits: ["remove"],
+  setup(props, { slots, emit }) {
+    return () =>
+      h("div", [
+        slots.default?.(),
+        h("button", { type: "button", onClick: () => emit("remove") }, "Remove"),
+      ]);
+  },
+});
+
+export const uiComponents: AutoFormUIComponents = {
+  Form,
+  FieldWrapper,
+  ErrorMessage,
+  SubmitButton,
+  ObjectWrapper,
+  ArrayWrapper,
+  ArrayElementWrapper,
+};
+```
+
+## Defining field components
+
+Field components render the actual inputs. Each receives `inputProps` with `modelValue` and `onUpdate:modelValue` for v-model compatibility:
+
+```ts
+import { defineComponent, h } from "vue";
+import type { AutoFormFieldComponents } from "@autoform/vue";
+
+const StringField = defineComponent({
+  props: ["field", "value", "error", "id", "inputProps"],
+  setup(props) {
+    return () =>
+      h("input", {
+        type: "text",
+        id: props.id,
+        value: props.inputProps?.modelValue ?? "",
+        onInput: (e: Event) =>
+          props.inputProps?.["onUpdate:modelValue"]?.(
+            (e.target as HTMLInputElement).value
+          ),
+      });
+  },
+});
+
+const NumberField = defineComponent({
+  props: ["field", "value", "error", "id", "inputProps"],
+  setup(props) {
+    return () =>
+      h("input", {
+        type: "number",
+        id: props.id,
+        value: props.inputProps?.modelValue ?? "",
+        onInput: (e: Event) => {
+          const val = (e.target as HTMLInputElement).value;
+          props.inputProps?.["onUpdate:modelValue"]?.(
+            val === "" ? undefined : Number(val)
+          );
+        },
+      });
+  },
+});
+
+const BooleanField = defineComponent({
+  props: ["field", "value", "error", "id", "inputProps"],
+  setup(props) {
+    return () =>
+      h("input", {
+        type: "checkbox",
+        id: props.id,
+        checked: !!props.inputProps?.modelValue,
+        onChange: (e: Event) =>
+          props.inputProps?.["onUpdate:modelValue"]?.(
+            (e.target as HTMLInputElement).checked
+          ),
+      });
+  },
+});
+
+const SelectField = defineComponent({
+  props: ["field", "value", "error", "id", "inputProps"],
+  setup(props) {
+    return () =>
+      h(
+        "select",
+        {
+          id: props.id,
+          value: props.inputProps?.modelValue ?? "",
+          onChange: (e: Event) =>
+            props.inputProps?.["onUpdate:modelValue"]?.(
+              (e.target as HTMLSelectElement).value
+            ),
+        },
+        [
+          h("option", { value: "", disabled: true }, "Select..."),
+          ...(props.field?.options || []).map(([val, label]: [string, string]) =>
+            h("option", { value: val, key: val }, label)
+          ),
+        ]
+      );
+  },
+});
+
+export const fieldComponents: AutoFormFieldComponents = {
+  string: StringField,
+  number: NumberField,
+  boolean: BooleanField,
+  select: SelectField,
+  fallback: StringField,
+};
+```
+
+</div>
+
+## Accessing form state
+
+Use a template ref to access the form's internal state:
+
+```vue
+<script setup>
+import { ref } from "vue";
+
+const formRef = ref();
+
+function resetForm() {
+  formRef.value?.reset();
+}
+</script>
+
+<template>
+  <AutoForm ref="formRef" :schema="schema" ... @submit="onSubmit" />
+  <button @click="resetForm">Reset</button>
+</template>
+```
+
+The exposed properties are: `values`, `errors`, `isSubmitting`, `reset()`.
+
+## Using the composable directly
+
+For full control over form state without the `AutoForm` component, use the `useAutoForm` composable inside the component tree:
+
+```ts
+import { useAutoForm } from "@autoform/vue";
+
+const { values, errors, setFieldValue, getFieldValue } = useAutoForm();
+```
+
+> Note: `useAutoForm()` must be called inside a component rendered within `<AutoForm>`.
+
+## Live Demo
+
+Check out the [live demo](https://mvtandas.github.io/autoform-vue-demo/) to see `@autoform/vue` in action.
+
+## Next Steps
+
+- [How to define your zod schema](/docs/schema-providers/zod)
+- [How to define your yup schema](/docs/schema-providers/yup)
+- [How to customize your form](/docs/vue/customization)
+- [API reference](/docs/vue/api)

--- a/apps/docs/content/docs/vue/meta.json
+++ b/apps/docs/content/docs/vue/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Vue",
+  "icon": "Component",
+  "pages": [
+    "---Guide---",
+    "getting-started",
+    "customization",
+    "api"
+  ]
+}

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,0 +1,52 @@
+# @autoform/vue
+
+Vue 3 integration for [AutoForm](https://github.com/vantezzen/autoform) — automatically render forms from your Zod/Yup schema.
+
+## Installation
+
+```bash
+pnpm add @autoform/vue @autoform/zod zod
+```
+
+## Usage
+
+`@autoform/vue` follows the same pattern as `@autoform/react`. You provide UI components and form field components, and AutoForm handles the rest.
+
+```vue
+<script setup lang="ts">
+import { AutoForm } from '@autoform/vue'
+import { ZodProvider } from '@autoform/zod'
+import { z } from 'zod'
+import { MyUIComponents, MyFieldComponents } from './my-components'
+
+const schema = new ZodProvider(
+  z.object({
+    name: z.string().min(2),
+    email: z.string().email(),
+    age: z.number().min(18),
+  })
+)
+
+function onSubmit(data: any) {
+  console.log('Validated:', data)
+}
+</script>
+
+<template>
+  <AutoForm
+    :schema="schema"
+    :ui-components="MyUIComponents"
+    :form-components="MyFieldComponents"
+    with-submit
+    @submit="onSubmit"
+  />
+</template>
+```
+
+## Documentation
+
+See the [AutoForm documentation](https://autoform.vantezzen.io) for full details on schema configuration, field customization, and more.
+
+## License
+
+MIT

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@autoform/vue",
+  "version": "1.0.0",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "lint": "eslint . --max-warnings 0",
+    "build": "tsup src/index.ts --format cjs,esm --dts --external vue",
+    "dev": "tsup src/index.ts --format cjs,esm --dts --external vue --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vantezzen/autoform"
+  },
+  "devDependencies": {
+    "@autoform/eslint-config": "*",
+    "@autoform/typescript-config": "*",
+    "@autoform/zod": "*",
+    "@autoform/yup": "*",
+    "@types/node": "^20.11.24",
+    "eslint": "^8.57.0",
+    "tsup": "^8.3.0",
+    "typescript": "^5.3.3",
+    "vue": "^3.5.0"
+  },
+  "dependencies": {
+    "@autoform/core": "*"
+  },
+  "peerDependencies": {
+    "vue": "^3.3.0"
+  }
+}

--- a/packages/vue/src/ArrayField.ts
+++ b/packages/vue/src/ArrayField.ts
@@ -1,0 +1,81 @@
+import { defineComponent, h, type PropType } from "vue";
+import { getLabel, type ParsedField } from "@autoform/core";
+import { useAutoForm } from "./context";
+import { AutoFormField } from "./AutoFormField";
+import { getPathInObject, setPathInObject } from "./utils";
+
+export const ArrayField = defineComponent({
+  name: "ArrayField",
+  props: {
+    field: {
+      type: Object as PropType<ParsedField>,
+      required: true,
+    },
+    path: {
+      type: Array as PropType<string[]>,
+      required: true,
+    },
+  },
+  setup(props) {
+    const { uiComponents, values } = useAutoForm();
+
+    function getArrayValue(): any[] {
+      const val = getPathInObject(values, props.path);
+      return Array.isArray(val) ? val : [];
+    }
+
+    function addItem() {
+      const subFieldType = props.field.schema?.[0]?.type;
+      let defaultValue: any;
+      if (subFieldType === "object") {
+        defaultValue = {};
+      } else if (subFieldType === "array") {
+        defaultValue = [];
+      } else {
+        defaultValue = null;
+      }
+
+      const current = getArrayValue();
+      setPathInObject(values, props.path, [...current, defaultValue]);
+    }
+
+    function removeItem(index: number) {
+      const current = getArrayValue();
+      current.splice(index, 1);
+      setPathInObject(values, props.path, [...current]);
+    }
+
+    return () => {
+      const items = getArrayValue();
+
+      return h(
+        uiComponents.ArrayWrapper,
+        {
+          label: getLabel(props.field),
+          field: props.field,
+          onAddItem: addItem,
+        },
+        {
+          default: () =>
+            items.map((_, index) =>
+              h(
+                uiComponents.ArrayElementWrapper,
+                {
+                  key: index,
+                  index,
+                  onRemove: () => removeItem(index),
+                },
+                {
+                  default: () =>
+                    h(AutoFormField, {
+                      field: props.field.schema![0]!,
+                      path: [...props.path, index.toString()],
+                    }),
+                }
+              )
+            ),
+        }
+      );
+    };
+  },
+});

--- a/packages/vue/src/AutoForm.ts
+++ b/packages/vue/src/AutoForm.ts
@@ -1,0 +1,176 @@
+import { defineComponent, h, reactive, ref, watch, type PropType } from "vue";
+import {
+  parseSchema,
+  getDefaultValues,
+  removeEmptyValues,
+  type SchemaProvider,
+} from "@autoform/core";
+import type {
+  AutoFormUIComponents,
+  AutoFormFieldComponents,
+} from "./types";
+import { provideAutoForm } from "./context";
+import { AutoFormField } from "./AutoFormField";
+import { getPathInObject, setPathInObject } from "./utils";
+
+export const AutoForm = defineComponent({
+  name: "AutoForm",
+  props: {
+    schema: {
+      type: Object as PropType<SchemaProvider>,
+      required: true,
+    },
+    defaultValues: {
+      type: Object as PropType<Record<string, any>>,
+      default: undefined,
+    },
+    values: {
+      type: Object as PropType<Record<string, any>>,
+      default: undefined,
+    },
+    uiComponents: {
+      type: Object as PropType<AutoFormUIComponents>,
+      required: true,
+    },
+    formComponents: {
+      type: Object as PropType<AutoFormFieldComponents>,
+      required: true,
+    },
+    withSubmit: {
+      type: Boolean,
+      default: false,
+    },
+    formProps: {
+      type: Object as PropType<Record<string, any>>,
+      default: () => ({}),
+    },
+  },
+  emits: ["submit", "formInit"],
+  setup(props, { emit, slots, expose }) {
+    const parsedSchema = parseSchema(props.schema);
+
+    const formValues = reactive<Record<string, any>>({
+      ...getDefaultValues(props.schema),
+      ...props.defaultValues,
+    });
+
+    const errors = ref<Record<string, string>>({});
+    const isSubmitting = ref(false);
+
+    // Sync external values
+    if (props.values) {
+      watch(
+        () => props.values,
+        (newValues) => {
+          if (newValues) {
+            Object.assign(formValues, newValues);
+          }
+        },
+        { deep: true }
+      );
+    }
+
+    function setFieldValue(path: string, value: any) {
+      setPathInObject(formValues, path.split("."), value);
+    }
+
+    function getFieldValue(path: string): any {
+      return getPathInObject(formValues, path.split("."));
+    }
+
+    function getFieldError(path: string): string | undefined {
+      return errors.value[path];
+    }
+
+    function clearErrors() {
+      errors.value = {};
+    }
+
+    function reset() {
+      Object.keys(formValues).forEach((key) => delete formValues[key]);
+      Object.assign(formValues, {
+        ...getDefaultValues(props.schema),
+        ...props.defaultValues,
+      });
+      clearErrors();
+    }
+
+    async function handleSubmit() {
+      isSubmitting.value = true;
+      clearErrors();
+
+      try {
+        const data = removeEmptyValues(formValues);
+        const validationResult = props.schema.validateSchema(data);
+
+        if (validationResult.success) {
+          await emit("submit", validationResult.data);
+        } else {
+          validationResult.errors?.forEach((error) => {
+            const path = error.path.join(".");
+            errors.value[path] = error.message;
+
+            // Handle zod's duplicate path issue
+            const correctedPath = error.path?.slice?.(0, -1);
+            if (correctedPath?.length > 0) {
+              errors.value[correctedPath.join(".")] = error.message;
+            }
+          });
+        }
+      } finally {
+        isSubmitting.value = false;
+      }
+    }
+
+    // Provide context to child components
+    provideAutoForm({
+      schema: parsedSchema,
+      uiComponents: props.uiComponents,
+      formComponents: props.formComponents,
+      values: formValues,
+      errors: errors.value,
+      setFieldValue,
+      getFieldValue,
+      getFieldError,
+    });
+
+    // Expose form controls
+    expose({ values: formValues, errors, isSubmitting, reset, clearErrors });
+
+    // Emit form init
+    emit("formInit", { values: formValues, errors, isSubmitting, reset, clearErrors });
+
+    return () => {
+      const FormComponent = props.uiComponents.Form;
+      const SubmitButton = props.uiComponents.SubmitButton;
+
+      return h(
+        FormComponent,
+        {
+          onSubmit: (e: Event) => {
+            e.preventDefault();
+            handleSubmit();
+          },
+          ...props.formProps,
+        },
+        {
+          default: () => [
+            ...parsedSchema.fields.map((field) =>
+              h(AutoFormField, {
+                key: field.key,
+                field,
+                path: [field.key],
+              })
+            ),
+            props.withSubmit
+              ? h(SubmitButton, null, {
+                  default: () => "Submit",
+                })
+              : null,
+            slots.default?.(),
+          ],
+        }
+      );
+    };
+  },
+});

--- a/packages/vue/src/AutoFormField.ts
+++ b/packages/vue/src/AutoFormField.ts
@@ -1,0 +1,80 @@
+import { defineComponent, h, type PropType } from "vue";
+import { getLabel, type ParsedField } from "@autoform/core";
+import { useAutoForm } from "./context";
+import { ObjectField } from "./ObjectField";
+import { ArrayField } from "./ArrayField";
+import { getPathInObject } from "./utils";
+
+export const AutoFormField = defineComponent({
+  name: "AutoFormField",
+  props: {
+    field: {
+      type: Object as PropType<ParsedField>,
+      required: true,
+    },
+    path: {
+      type: Array as PropType<string[]>,
+      required: true,
+    },
+  },
+  setup(props) {
+    const { formComponents, uiComponents, values, errors, setFieldValue } =
+      useAutoForm();
+
+    return () => {
+      const fullPath = props.path.join(".");
+      const error = getPathInObject(errors, props.path.join(".").split("."))
+        ?? errors[fullPath as keyof typeof errors];
+      const value = getPathInObject(values, props.path);
+      const label = getLabel(props.field);
+
+      const FieldWrapper =
+        props.field.fieldConfig?.fieldWrapper || uiComponents.FieldWrapper;
+
+      let FieldComponent: any;
+
+      if (props.field.type === "array") {
+        FieldComponent = ArrayField;
+      } else if (props.field.type === "object") {
+        FieldComponent = ObjectField;
+      } else if (props.field.type in formComponents) {
+        FieldComponent = formComponents[props.field.type]!;
+      } else if ("fallback" in formComponents) {
+        FieldComponent = formComponents.fallback;
+      } else {
+        return h(uiComponents.ErrorMessage, {
+          error: `[AutoForm] No component found for type "${props.field.type}"`,
+        });
+      }
+
+      return h(
+        FieldWrapper,
+        {
+          label,
+          error: typeof error === 'string' ? error : undefined,
+          id: fullPath,
+          field: props.field,
+        },
+        {
+          default: () =>
+            h(FieldComponent, {
+              label,
+              field: props.field,
+              value,
+              error: typeof error === 'string' ? error : undefined,
+              id: fullPath,
+              path: props.path,
+              inputProps: {
+                required: props.field.required,
+                ...props.field.fieldConfig?.inputProps,
+                modelValue: value,
+                "onUpdate:modelValue": (newValue: any) => {
+                  setFieldValue(fullPath, newValue);
+                },
+              },
+            }),
+        }
+      );
+    };
+  },
+});

--- a/packages/vue/src/AutoFormField.ts
+++ b/packages/vue/src/AutoFormField.ts
@@ -23,10 +23,19 @@ export const AutoFormField = defineComponent({
 
     return () => {
       const fullPath = props.path.join(".");
-      const error = getPathInObject(errors, props.path.join(".").split("."))
-        ?? errors[fullPath as keyof typeof errors];
+      const error =
+        getPathInObject(errors, props.path.join(".").split(".")) ??
+        errors[fullPath as keyof typeof errors];
       const value = getPathInObject(values, props.path);
       const label = getLabel(props.field);
+
+      // Compute description, avoiding duplicate when it matches the label
+      const rawDescription =
+        props.field.fieldConfig?.description ?? props.field.description;
+      const description =
+        typeof rawDescription === "string" && rawDescription !== label
+          ? rawDescription
+          : undefined;
 
       const FieldWrapper =
         props.field.fieldConfig?.fieldWrapper || uiComponents.FieldWrapper;
@@ -51,7 +60,8 @@ export const AutoFormField = defineComponent({
         FieldWrapper,
         {
           label,
-          error: typeof error === 'string' ? error : undefined,
+          description,
+          error: typeof error === "string" ? error : undefined,
           id: fullPath,
           field: props.field,
         },
@@ -61,7 +71,7 @@ export const AutoFormField = defineComponent({
               label,
               field: props.field,
               value,
-              error: typeof error === 'string' ? error : undefined,
+              error: typeof error === "string" ? error : undefined,
               id: fullPath,
               path: props.path,
               inputProps: {

--- a/packages/vue/src/ObjectField.ts
+++ b/packages/vue/src/ObjectField.ts
@@ -1,0 +1,41 @@
+import { defineComponent, h, type PropType } from "vue";
+import { getLabel, type ParsedField } from "@autoform/core";
+import { useAutoForm } from "./context";
+import { AutoFormField } from "./AutoFormField";
+
+export const ObjectField = defineComponent({
+  name: "ObjectField",
+  props: {
+    field: {
+      type: Object as PropType<ParsedField>,
+      required: true,
+    },
+    path: {
+      type: Array as PropType<string[]>,
+      required: true,
+    },
+  },
+  setup(props) {
+    const { uiComponents } = useAutoForm();
+
+    return () => {
+      return h(
+        uiComponents.ObjectWrapper,
+        {
+          label: getLabel(props.field),
+          field: props.field,
+        },
+        {
+          default: () =>
+            (props.field.schema || []).map((subField) =>
+              h(AutoFormField, {
+                key: `${props.path.join(".")}.${subField.key}`,
+                field: subField,
+                path: [...props.path, subField.key],
+              })
+            ),
+        }
+      );
+    };
+  },
+});

--- a/packages/vue/src/context.ts
+++ b/packages/vue/src/context.ts
@@ -1,0 +1,17 @@
+import { inject, provide } from "vue";
+import type { InjectionKey } from "vue";
+import type { AutoFormContextType } from "./types";
+
+const AutoFormKey: InjectionKey<AutoFormContextType> = Symbol("AutoForm");
+
+export function provideAutoForm(context: AutoFormContextType) {
+  provide(AutoFormKey, context);
+}
+
+export function useAutoForm(): AutoFormContextType {
+  const context = inject(AutoFormKey);
+  if (!context) {
+    throw new Error("useAutoForm must be used within an AutoForm component");
+  }
+  return context;
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,0 +1,7 @@
+export { AutoForm } from "./AutoForm";
+export { AutoFormField } from "./AutoFormField";
+export { ObjectField } from "./ObjectField";
+export { ArrayField } from "./ArrayField";
+export { useAutoForm, provideAutoForm } from "./context";
+export { getPathInObject, setPathInObject, buildZodFieldConfig, buildYupFieldConfig } from "./utils";
+export * from "./types";

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -1,0 +1,92 @@
+import type { Component, VNode } from "vue";
+import type {
+  ParsedField,
+  ParsedSchema,
+  Renderable,
+  SchemaProvider,
+  FieldConfig as BaseFieldConfig,
+} from "@autoform/core";
+
+export interface AutoFormProps<T extends Record<string, any> = Record<string, any>> {
+  schema: SchemaProvider<T>;
+  defaultValues?: Partial<T>;
+  values?: Partial<T>;
+  uiComponents: AutoFormUIComponents;
+  formComponents: AutoFormFieldComponents;
+  withSubmit?: boolean;
+  formProps?: Record<string, any>;
+}
+
+export type ExtendableAutoFormProps<T extends Record<string, any> = Record<string, any>> = Omit<
+  AutoFormProps<T>,
+  "uiComponents" | "formComponents"
+> & {
+  uiComponents?: Partial<AutoFormUIComponents>;
+  formComponents?: Partial<AutoFormFieldComponents>;
+};
+
+export interface AutoFormUIComponents {
+  Form: Component;
+  FieldWrapper: Component;
+  ErrorMessage: Component;
+  SubmitButton: Component;
+  ObjectWrapper: Component;
+  ArrayWrapper: Component;
+  ArrayElementWrapper: Component;
+}
+
+export interface AutoFormFieldComponents {
+  [key: string]: Component;
+}
+
+export interface FieldWrapperProps {
+  label: Renderable<VNode>;
+  error?: Renderable<VNode>;
+  id: string;
+  field: ParsedField;
+}
+
+export interface ArrayWrapperProps {
+  label: Renderable<VNode>;
+  field: ParsedField;
+}
+
+export interface ArrayElementWrapperProps {
+  index: number;
+}
+
+export interface ObjectWrapperProps {
+  label: Renderable<VNode>;
+  field: ParsedField;
+}
+
+export interface AutoFormFieldProps {
+  label: Renderable<VNode>;
+  field: ParsedField;
+  value: any;
+  error?: string;
+  id: string;
+  path: string[];
+  inputProps: any;
+}
+
+export interface AutoFormContextType {
+  schema: ParsedSchema;
+  uiComponents: AutoFormUIComponents;
+  formComponents: AutoFormFieldComponents;
+  values: Record<string, any>;
+  errors: Record<string, string>;
+  setFieldValue: (path: string, value: any) => void;
+  getFieldValue: (path: string) => any;
+  getFieldError: (path: string) => string | undefined;
+}
+
+export type FieldConfig<
+  FieldTypes = string,
+  CustomData = Record<string, any>,
+> = BaseFieldConfig<
+  VNode,
+  FieldTypes,
+  Component,
+  CustomData
+>;

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -41,6 +41,7 @@ export interface AutoFormFieldComponents {
 
 export interface FieldWrapperProps {
   label: Renderable<VNode>;
+  description?: string;
   error?: Renderable<VNode>;
   id: string;
   field: ParsedField;

--- a/packages/vue/src/utils.ts
+++ b/packages/vue/src/utils.ts
@@ -1,0 +1,64 @@
+import type { Component, VNode } from "vue";
+import type { FieldConfig } from "@autoform/core";
+import type { FieldWrapperProps } from "./types";
+
+export function getPathInObject(obj: any, path: string[]): any {
+  let current = obj;
+  for (const key of path) {
+    if (current === undefined || current === null) {
+      return undefined;
+    }
+    current = current[key];
+  }
+  return current;
+}
+
+export function setPathInObject(obj: any, path: string[], value: any): void {
+  let current = obj;
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i]!;
+    if (current[key] === undefined || current[key] === null) {
+      current[key] = isNaN(Number(path[i + 1])) ? {} : [];
+    }
+    current = current[key];
+  }
+  current[path[path.length - 1]!] = value;
+}
+
+// Build field config helpers for schema providers
+export function buildZodFieldConfig<
+  FieldTypes = string,
+  CustomData = Record<string, any>,
+>() {
+  return (
+    config: FieldConfig<VNode, FieldTypes, Component, CustomData>
+  ) => {
+    // Lazy import to avoid requiring zod as dependency
+    try {
+      const { fieldConfig: zodFieldConfig } = require("@autoform/zod");
+      return zodFieldConfig<VNode, FieldTypes, Component, CustomData>(config);
+    } catch {
+      throw new Error(
+        "buildZodFieldConfig requires @autoform/zod to be installed"
+      );
+    }
+  };
+}
+
+export function buildYupFieldConfig<
+  FieldTypes = string,
+  CustomData = Record<string, any>,
+>() {
+  return (
+    config: FieldConfig<VNode, FieldTypes, Component, CustomData>
+  ) => {
+    try {
+      const { fieldConfig: yupFieldConfig } = require("@autoform/yup");
+      return yupFieldConfig<VNode, FieldTypes, Component, CustomData>(config);
+    } catch {
+      throw new Error(
+        "buildYupFieldConfig requires @autoform/yup to be installed"
+      );
+    }
+  };
+}

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "jsx": "preserve"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Adds the Vue 3 integration for AutoForm as `@autoform/vue`, following the same architecture as `@autoform/react`.

Closes #199

## What's included

### Components
| Component | Description |
|-----------|-------------|
| `AutoForm` | Main form component — parses schema, manages state, validates, submits |
| `AutoFormField` | Renders individual fields based on schema type |
| `ObjectField` | Handles nested object schemas recursively |
| `ArrayField` | Handles array schemas with add/remove support |

### Composables
| Export | Description |
|--------|-------------|
| `useAutoForm()` | Inject context from nearest `AutoForm` parent |
| `provideAutoForm()` | Provide context (used internally by `AutoForm`) |

### Utilities
| Export | Description |
|--------|-------------|
| `buildZodFieldConfig()` | Type-safe Zod field config builder for Vue |
| `buildYupFieldConfig()` | Type-safe Yup field config builder for Vue |
| `getPathInObject()` | Read nested value by path |
| `setPathInObject()` | Set nested value by path |

## Architecture

Follows the exact same pattern as `@autoform/react`:

```
@autoform/core          → Schema parsing, validation (shared)
@autoform/zod           → Zod adapter (shared)
@autoform/vue (NEW)     → Vue 3 component layer
@autoform/shadcn-vue    → UI components (future)
```

Key differences from React version:
- Uses Vue 3 `reactive()` instead of `react-hook-form` for form state
- Uses `provide/inject` instead of React Context
- Uses `h()` render functions (pure TS, no SFC/JSX needed)
- Uses `v-model` compatible `inputProps` for field binding

## Usage

```vue
<script setup>
import { AutoForm } from '@autoform/vue'
import { ZodProvider } from '@autoform/zod'
import { z } from 'zod'

const schema = new ZodProvider(
  z.object({
    name: z.string().min(2),
    email: z.string().email(),
    role: z.enum(['developer', 'designer']),
  })
)
</script>

<template>
  <AutoForm
    :schema="schema"
    :ui-components="uiComponents"
    :form-components="fieldComponents"
    with-submit
    @submit="console.log"
  />
</template>
```

## Build

CJS + ESM builds pass successfully via `tsup`. TypeScript types are fully exported.

## Next steps (future PRs)

- [ ] `@autoform/shadcn-vue` — Styled components using shadcn-vue
- [ ] Add to documentation site
- [ ] Add examples