### PR TITLE
fix: remove extra npx in react package source installation command

### DIFF
--- a/apps/docs/content/docs/react/customization.mdx
+++ b/apps/docs/content/docs/react/customization.mdx
@@ -510,7 +510,7 @@ In some cases, you may need customization that isn't supported by the package AP
 
 <ModeTab
   mode="cli"
-  command="npx shadcn@latest add https://raw.githubusercontent.com/vantezzen/autoform/refs/heads/main/packages/shadcn/registry/autoform-react-source-rhf.json"
+  command="shadcn@latest add https://raw.githubusercontent.com/vantezzen/autoform/refs/heads/main/packages/shadcn/registry/autoform-react-source-rhf.json"
 />
 
 The adapter files will be added to `lib/autoform/react/`. You can change them as needed.

--- a/apps/docs/content/docs/tanstack/customization.mdx
+++ b/apps/docs/content/docs/tanstack/customization.mdx
@@ -435,7 +435,7 @@ In some cases, you may need customization that isn't supported by the package AP
 
 <ModeTab
   mode="cli"
-  command="npx shadcn@latest add https://raw.githubusercontent.com/vantezzen/autoform/refs/heads/main/packages/shadcn/registry/autoform-react-source-tanstack.json"
+  command="shadcn@latest add https://raw.githubusercontent.com/vantezzen/autoform/refs/heads/main/packages/shadcn/registry/autoform-react-source-tanstack.json"
 />
 
 The adapter files will be added to `lib/autoform/react/`. You can change them as needed.


### PR DESCRIPTION
Removes a duplicate `npx` in the react package source installation command.